### PR TITLE
Salesman payments with cash and taxes

### DIFF
--- a/src/lib/components/charts/MonthlyPayments.svelte
+++ b/src/lib/components/charts/MonthlyPayments.svelte
@@ -2,13 +2,18 @@
 import { goto } from "$app/navigation";
 import { page } from "$app/stores";
 import { waitForElm, printCanvas } from "$lib/element";
-import type { SalesmanPayments } from "$lib/server/database/deal";
+import type { CashDeals, SalesmanPayments } from "$lib/server/database/deal";
 import { Chart } from "chart.js/auto";
 import { onMount } from "svelte";
 import { data } from "./monthly-payments-data";
 import { groupSalesmanPayments } from "$lib/finance";
+import { formatCurrency } from "$lib/format";
+import { sum } from "$lib/sum";
 
-const { payments }: { payments: SalesmanPayments } = $props();
+const {
+	payments,
+	cashDeals,
+}: { payments: SalesmanPayments; cashDeals: CashDeals } = $props();
 
 let ctx: HTMLCanvasElement | null = null;
 
@@ -17,18 +22,24 @@ let filterYear = $state<number | string>(
 	Number($page.url.searchParams?.get("year")) || "",
 );
 
+let taxRate = $state(15.3);
+
 let stacked = $state(true);
 
-const chartData = $derived(
-	data(
-		groupSalesmanPayments(payments, {
-			salesman: true,
-			quarter: groupBy.includes("quarter"),
-			year: groupBy.includes("year"),
-			month: groupBy.includes("month"),
-		}),
-	),
+const grouped = $derived(
+	groupSalesmanPayments(payments, cashDeals, {
+		salesman: true,
+		quarter: groupBy.includes("quarter"),
+		year: groupBy.includes("year"),
+		month: groupBy.includes("month"),
+	}),
 );
+
+let chartKey = $state<keyof typeof grouped>("paymentsGrouped");
+
+let groupedElement = $derived(grouped[chartKey]);
+
+const chartData = $derived(data(groupedElement));
 
 $effect(() => {
 	const newUrl = new URL($page.url);
@@ -124,62 +135,122 @@ onMount(() => {
     Stacked
     <input type="checkbox" bind:checked={stacked} />
   </label>
-	<div class='flex gap-4'>
-	Group by
-  <label>
-  	 quarter
-  	<input
-  	  type="checkbox"
-  	  checked={groupBy.includes('quarter')}
-			onchange = {(v) => {
-			  const isChecked = v.target?.checked as boolean;
-			  toggleGroupBy('quarter', isChecked)
-			}}
-  	/>
-  </label>
-  	{#if !(groupBy.includes('quarter'))}
-  <label>
-  	 month
-  	<input
-  	  type="checkbox"
-  	  checked={groupBy.includes('month')}
-			onchange = {(v) => {
-			  const isChecked = v.target?.checked as boolean;
-			  toggleGroupBy('month', isChecked)
-			}}
-  	/>
-  </label>
-  <label>
-	  year	
-  	<input
-  	  type="checkbox"
-  	  checked={groupBy.includes('year')}
-			onchange = {(v) => {
-			  const isChecked = v.target?.checked as boolean;
-			  toggleGroupBy('year', isChecked)
-			}}
-  	/>
-  </label>
-{/if}
-  <label class='flex items-center gap-2 ml-auto'>
-  	Year
-  <select class="input select preset-tonal-surface" bind:value={filterYear}>
-  		<option value="">No year</option>
-  	{#each Array.from(new Array(new Date().getFullYear() - 2020 )) as _, k}
-  		{@const year = 2020 + k + 1}
-  		<option value={year} >
-	  		{year}
-  		</option>
-  	{/each}
-  </select>
-  </label>
+  <div class="flex gap-4">
+    Group by
+    <label>
+      quarter
+      <input
+        type="checkbox"
+        checked={groupBy.includes("quarter")}
+        onchange={(v) => {
+          const isChecked = v.target?.checked as boolean;
+          toggleGroupBy("quarter", isChecked);
+        }}
+      />
+    </label>
+    {#if !groupBy.includes("quarter")}
+      <label>
+        month
+        <input
+          type="checkbox"
+          checked={groupBy.includes("month")}
+          onchange={(v) => {
+            const isChecked = v.target?.checked as boolean;
+            toggleGroupBy("month", isChecked);
+          }}
+        />
+      </label>
+      <label>
+        year
+        <input
+          type="checkbox"
+          checked={groupBy.includes("year")}
+          onchange={(v) => {
+            const isChecked = v.target?.checked as boolean;
+            toggleGroupBy("year", isChecked);
+          }}
+        />
+      </label>
+    {/if}
+    <label class="flex items-center gap-2 ml-auto">
+      Year
+      <select class="input select preset-tonal-surface" bind:value={filterYear}>
+        <option value="">No year</option>
+        {#each Array.from(new Array(new Date().getFullYear() - 2020)) as _, k}
+          {@const year = 2020 + k + 1}
+          <option value={year}>
+            {year}
+          </option>
+        {/each}
+      </select>
+    </label>
+    <label class="flex gap-2 items-center">
+      Chart Values
+      <select
+        bind:value={chartKey}
+        class="input select preset-tonal-surface w-fit"
+      >
+        <option value="paymentsGrouped">Payments</option>
+        <option value="cashDealsGrouped">Cash Deals</option>
+        <option value="totalGrouped">Total</option>
+      </select>
+    </label>
 
-		<button class="btn preset-tonal-secondary " type="button" onclick={() => {
-			if (!ctx) return
-			printCanvas(ctx?.toDataURL(), chartOptions.plugins.title.text)
-		}}>
-			Print
-		</button>
-	</div>
-  <canvas bind:this={ctx} id="monthlyPayments"></canvas>
+    <button
+      class="btn preset-tonal-secondary"
+      type="button"
+      onclick={() => {
+        if (!ctx) return;
+        printCanvas(ctx?.toDataURL(), chartOptions.plugins.title.text);
+      }}
+    >
+      Print
+    </button>
+  </div>
+  <div class="print:hidden">
+    <canvas bind:this={ctx} id="monthlyPayments"></canvas>
+  </div>
 </div>
+
+<label>
+  Tax %
+  <input bind:value={taxRate} type="number" class="input" />
+</label>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Salesman</th>
+      <th>Payments</th>
+      <th>Cash</th>
+      <th>Total</th>
+      <th>Tax <span class="text-sm"> - {taxRate}%</span></th>
+    </tr>
+  </thead>
+  <tbody>
+    {#each chartData["labels"] as group}
+      {#each Object.keys(grouped["totalGrouped"][group]) as salesman}
+        {@const total = sum(grouped["totalGrouped"]?.[group]?.[salesman] || [])}
+        <tr>
+          <td>{salesman}</td>
+          <td>
+            {formatCurrency(
+              sum(grouped["paymentsGrouped"]?.[group]?.[salesman] || []),
+            )}
+          </td>
+          <td>
+            {formatCurrency(
+              sum(grouped["cashDealsGrouped"]?.[group]?.[salesman] || []),
+            )}
+          </td>
+          <td>
+            {formatCurrency(total)}
+          </td>
+          <td>
+            {formatCurrency(total * (taxRate / 100))}
+          </td>
+        </tr>
+      {/each}
+    {/each}
+  </tbody>
+</table>

--- a/src/lib/components/charts/monthly-payments-data.ts
+++ b/src/lib/components/charts/monthly-payments-data.ts
@@ -1,11 +1,11 @@
+import type { GroupedSalesmanPayments } from "$lib/finance/groupSalesmanPayments";
 import { stringToColorHsl, stringToHash } from "$lib/format/stringToColor";
-import type { GroupedSalesmanPayments } from "$lib/server/database/deal";
 import { sum } from "$lib/sum";
 
-export const data = (payments: GroupedSalesmanPayments) => {
-	const labelsSet = Object.keys(payments).reduce(
+export const data = (amounts: GroupedSalesmanPayments) => {
+	const labelsSet = Object.keys(amounts).reduce(
 		(acc, k) => {
-			const theseLabels = Object.keys(payments[k]);
+			const theseLabels = Object.keys(amounts[k]);
 
 			for (const label of theseLabels) {
 				acc.add(label);
@@ -18,14 +18,14 @@ export const data = (payments: GroupedSalesmanPayments) => {
 
 	const allLabels = Array.from(labelsSet).sort();
 	const hashes = allLabels.map((label) => stringToHash(label));
-	const keys = Object.keys(payments);
+	const keys = Object.keys(amounts);
 	const baseData = Array.from(new Array(allLabels.length)).map((_k) => {
 		return Array.from(new Array(keys).keys()).map((_) => 0);
 	});
 
 	for (let i = 0; i < keys.length; i++) {
 		const key = keys[i];
-		const salesmen = payments[key];
+		const salesmen = amounts[key];
 
 		for (const [salesman, payments] of Object.entries(salesmen)) {
 			const index = allLabels.indexOf(salesman);

--- a/src/lib/finance/groupSalesmanPayments.ts
+++ b/src/lib/finance/groupSalesmanPayments.ts
@@ -1,48 +1,114 @@
 import { formatSalesmen } from "$lib/format";
 import type {
+	CashDeals,
 	SalemanPaymentsGroupBy,
 	SalesmanPayments,
 } from "$lib/server/database/deal";
 import { formatDate } from "date-fns";
+// import { writeFileSync } from "fs";
+
+const getDateKey = (date: Date | string, q?: SalemanPaymentsGroupBy) => {
+	return q?.month || q?.year || q?.quarter
+		? formatDate(
+				date,
+				q.quarter
+					? "QQQ yyyy"
+					: `${q?.month ? "MM" : ""}${q?.year && q?.month ? "-" : ""}${
+							q?.year ? "yyyy" : ""
+						}`,
+			)
+		: "";
+};
+export type GroupedSalesmanPayments = {
+	[date: string]: {
+		[salesman: string]: number[];
+	};
+};
 
 export const groupSalesmanPayments = (
 	payments: SalesmanPayments,
+	cashDeals?: CashDeals,
 	q?: SalemanPaymentsGroupBy,
 ) => {
-	return payments?.reduce(
-		(acc, curr) => {
+	const totalGrouped: GroupedSalesmanPayments = {};
+	const paymentsGrouped = payments?.reduce((acc, curr) => {
+		const date = new Date(curr.date);
+		const salesman =
+			formatSalesmen(curr.deal.inventory.inventory_salesman, "contact") ||
+			"Unasigned";
+
+		const amount = Number(curr.amount);
+		const dateKey = getDateKey(date, q);
+
+		if (dateKey in acc) {
+			if (salesman in acc[dateKey]) {
+				acc[dateKey][salesman].push(amount);
+			} else {
+				acc[dateKey][salesman] = [amount];
+			}
+		} else {
+			acc[dateKey] = {
+				[salesman]: [amount],
+			};
+		}
+		if (dateKey in totalGrouped) {
+			if (salesman in totalGrouped[dateKey]) {
+				totalGrouped[dateKey][salesman].push(amount);
+			} else {
+				totalGrouped[dateKey][salesman] = [amount];
+			}
+		} else {
+			totalGrouped[dateKey] = {
+				[salesman]: [amount],
+			};
+		}
+
+		return acc;
+	}, {} as GroupedSalesmanPayments);
+
+	const cashDealsGrouped: GroupedSalesmanPayments = {};
+
+	if (cashDeals) {
+		for (const curr of cashDeals) {
 			const date = new Date(curr.date);
 			const salesman =
-				formatSalesmen(curr.deal.inventory.inventory_salesman, "contact") ||
+				formatSalesmen(curr.inventory.inventory_salesman, "contact") ||
 				"Unasigned";
-			const dateKey =
-				q?.month || q?.year || q?.quarter
-					? formatDate(
-							date,
-							q.quarter
-								? "QQQ yyyy"
-								: `${q?.month ? "MM" : ""}${q?.year && q?.month ? "-" : ""}${
-										q?.year ? "yyyy" : ""
-									}`,
-						)
-					: "";
 
-			const amount = Number(curr.amount);
+			const amount = Number(curr.cash);
+			if (Number.isNaN(amount)) continue;
+			const dateKey = getDateKey(date, q);
 
-			if (dateKey in acc) {
-				if (salesman in acc[dateKey]) {
-					acc[dateKey][salesman].push(amount);
+			if (dateKey in cashDealsGrouped) {
+				if (salesman in cashDealsGrouped[dateKey]) {
+					cashDealsGrouped[dateKey][salesman].push(amount);
 				} else {
-					acc[dateKey][salesman] = [amount];
+					cashDealsGrouped[dateKey][salesman] = [amount];
 				}
 			} else {
-				acc[dateKey] = {
+				cashDealsGrouped[dateKey] = {
 					[salesman]: [amount],
 				};
 			}
+			if (dateKey in totalGrouped) {
+				if (salesman in totalGrouped[dateKey]) {
+					totalGrouped[dateKey][salesman].push(amount);
+				} else {
+					totalGrouped[dateKey][salesman] = [amount];
+				}
+			} else {
+				totalGrouped[dateKey] = {
+					[salesman]: [amount],
+				};
+			}
+		}
+	}
 
-			return acc;
-		},
-		{} as { [key: string]: { [key: string]: number[] } },
-	);
+	// if (!browser) {
+	// 	writeFileSync("./cash.json", JSON.stringify(cashDealsGrouped, null, 2));
+	// 	writeFileSync("./total.json", JSON.stringify(totalGrouped, null, 2));
+	// 	writeFileSync("./payments.json", JSON.stringify(paymentsGrouped, null, 2));
+	// }
+
+	return { paymentsGrouped, cashDealsGrouped, totalGrouped };
 };

--- a/src/lib/server/database/deal/getSalesmanPayments.ts
+++ b/src/lib/server/database/deal/getSalesmanPayments.ts
@@ -61,6 +61,52 @@ export const getSalesmanPayments = async (q?: SalesmanPaymentsQuery) => {
 	});
 };
 
+export const getCashDeals = async (q?: SalesmanPaymentsQuery) => {
+	return prisma.deal.findMany({
+		include: {
+			inventory: {
+				select: {
+					inventory_salesman: {
+						select: {
+							salesman: {
+								select: {
+									contact: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		orderBy: {
+			state: "asc",
+		},
+		where: {
+			date: q?.date
+				? typeof q?.date === "string"
+					? {}
+					: {
+							gte: q.date.gte,
+							lte: q.date.lte,
+						}
+				: undefined,
+			cash: {
+				gte: "0.00",
+			},
+			OR: [
+				{
+					lien: {
+						lte: "0.00",
+					},
+				},
+				{
+					lien: null,
+				},
+			],
+		},
+	});
+};
+export type CashDeals = Prisma.PromiseReturnType<typeof getCashDeals>;
 export type SalesmanPayments = Prisma.PromiseReturnType<
 	typeof getSalesmanPayments
 >;

--- a/src/lib/server/database/deal/getSalesmanPayments.ts
+++ b/src/lib/server/database/deal/getSalesmanPayments.ts
@@ -107,6 +107,7 @@ export const getCashDeals = async (q?: SalesmanPaymentsQuery) => {
 	});
 };
 export type CashDeals = Prisma.PromiseReturnType<typeof getCashDeals>;
+
 export type SalesmanPayments = Prisma.PromiseReturnType<
 	typeof getSalesmanPayments
 >;
@@ -121,8 +122,9 @@ export type SalemanPaymentsGroupBy = {
 export const getGroupedSalesmanPayments = async (
 	q?: SalesmanPaymentsQuery & { groupBy: SalemanPaymentsGroupBy },
 ) => {
+	const cashDeals = await getCashDeals(q);
 	return getSalesmanPayments(q).then((r) =>
-		groupSalesmanPayments(r, q?.groupBy),
+		groupSalesmanPayments(r, cashDeals, q?.groupBy),
 	);
 };
 

--- a/src/routes/(manage)/admin/charts/salesman-payments/+page.server.ts
+++ b/src/routes/(manage)/admin/charts/salesman-payments/+page.server.ts
@@ -1,6 +1,6 @@
 import { addMonths } from "date-fns";
 import type { PageServerLoad } from "./$types";
-import { getSalesmanPayments } from "$lib/server/database/deal";
+import { getCashDeals, getSalesmanPayments } from "$lib/server/database/deal";
 
 export const load: PageServerLoad = async ({ url }) => {
 	const yearFilter = url.searchParams.get("year");
@@ -8,6 +8,8 @@ export const load: PageServerLoad = async ({ url }) => {
 	const startDateFilter = yearFilter
 		? new Date(Number(yearFilter) - 1, 12, 1)
 		: undefined;
+
+	const cashDeals = await getCashDeals();
 
 	const payments = await getSalesmanPayments({
 		date: {
@@ -20,5 +22,5 @@ export const load: PageServerLoad = async ({ url }) => {
 		},
 	});
 
-	return { payments };
+	return { payments, cashDeals };
 };

--- a/src/routes/(manage)/admin/charts/salesman-payments/+page.svelte
+++ b/src/routes/(manage)/admin/charts/salesman-payments/+page.svelte
@@ -10,4 +10,4 @@ onMount(() => {
 });
 </script>
 
-<MonthlyPayments payments={data.payments} />
+<MonthlyPayments payments={data.payments} cashDeals={data.cashDeals} />


### PR DESCRIPTION
- Update the database and API to optionally include cash deal amounts.
- Display chart data & simple approximate taxes in a table.
- Present a number input to change tax rate.

Resolves #29