### PR TITLE
Edit salesmen

### DIFF
--- a/src/routes/(manage)/admin/+layout.svelte
+++ b/src/routes/(manage)/admin/+layout.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
-import Tabs from "$lib/components/tabs/Tabs.svelte";
+  import Tabs from "$lib/components/tabs/Tabs.svelte";
 
-const { children } = $props();
+  const { children } = $props();
 </script>
 
 <Tabs
   title={"Admin"}
-  tabs={[{ text: "admin", id: "" }, "kv", "charts"]}
+  tabs={[
+    { text: "admin", id: "" },
+    "kv",
+    "charts",
+    {
+      text: "match accounts",
+      id: "match-accounts",
+    },
+  ]}
   asLinks
   rootUrl="/admin"
 >

--- a/src/routes/(manage)/admin/match-accounts/+page.server.ts
+++ b/src/routes/(manage)/admin/match-accounts/+page.server.ts
@@ -1,0 +1,201 @@
+import { prisma } from "$lib/server/database";
+import { fail } from "@sveltejs/kit";
+import type { Actions } from "./$types";
+import { randomUUID } from "node:crypto";
+
+const getSalesmenContactIds = async () => {
+	return prisma.salesman
+		.findMany({
+			select: {
+				contact: {
+					select: {
+						id: true,
+					},
+				},
+			},
+		})
+		.then((r) => r.map((r) => r.contact.id));
+};
+
+export const load = async () => {
+	const missingAccounts = await prisma.person.findMany({
+		select: {
+			id: true,
+			lastName: true,
+			firstName: true,
+			account: {
+				select: {
+					id: true,
+					licenseNumber: true,
+				},
+			},
+		},
+		where: {
+			creditor: { none: {} },
+		},
+		orderBy: [
+			{
+				salesman: {
+					id: "desc",
+				},
+			},
+			{
+				lastName: "asc",
+			},
+			{
+				firstName: "asc",
+			},
+		],
+	});
+
+	const salesmen = await getSalesmenContactIds();
+	return { missing: missingAccounts, salesmen };
+};
+
+export const actions = {
+	save: async ({ request }) => {
+		const data = await request.formData();
+		const contactLinkIds = data.getAll("link-id") as string[];
+		const salesmen = data.getAll("salesman") as string[];
+		const primary = data.get("link-primary") as string;
+
+		// Update account license numbers; create account if not exists.
+		for (const [k, v] of data.entries()) {
+			if (!k.endsWith("-license") || typeof v !== "string") continue;
+			const contact = k.split("-license")[0];
+			if (!contact) continue;
+			await prisma.account.upsert({
+				where: {
+					contact_id: contact,
+				},
+				update: {
+					licenseNumber: v,
+				},
+				create: {
+					id: randomUUID(),
+					contact_id: contact,
+					licenseNumber: v,
+				},
+			});
+		}
+
+    // Merge accounts.
+    // Find matching deals for non-primary accounts then update to use primary.
+		if (contactLinkIds.length > 1) {
+			if (!primary) {
+				return fail(400, {
+					message: "Select an account primary or unselect merging accounts.",
+				});
+			}
+			await prisma
+				.$transaction(async (cx) => {
+					const accounts = await cx.account.findMany({
+						where: {
+							contact: {
+								id: {
+									in: contactLinkIds,
+								},
+							},
+						},
+						include: {
+							deals: {
+								select: {
+									id: true,
+									date: true,
+									account: true,
+									inventory: true,
+								},
+							},
+							contact: {
+								select: { id: true },
+							},
+						},
+					});
+					const primaryAccount = accounts.find((a) => a.contact.id === primary);
+					if (!primaryAccount) {
+						throw new Error("Invalid primary account");
+					}
+
+					const dealUpdates = accounts.reduce(
+						(acc, account) => {
+							for (const deal of account.deals) {
+								const match = acc.find((d) => {
+									return (
+										d.inventory.id === deal.inventory.id && d.date === deal.date
+									);
+								});
+								if (match) {
+									console.log("match", match);
+									continue;
+								}
+								acc.push(deal);
+							}
+
+							return acc;
+						},
+						[] as (typeof accounts)[number]["deals"],
+					);
+
+					await cx.deal.updateMany({
+						where: {
+							id: {
+								in: dealUpdates.map((d) => d.id),
+							},
+						},
+						data: {
+							accountId: primaryAccount.id,
+						},
+					});
+
+					const toDelete = contactLinkIds.filter((c) => c !== primary);
+
+					await cx.person.deleteMany({
+						where: {
+							id: {
+								in: toDelete,
+							},
+						},
+					});
+
+					await cx.account.deleteMany({
+						where: {
+							id: {
+								in: accounts
+									.filter((acc) => acc.id !== primaryAccount.id)
+									.map((m) => m.id),
+							},
+						},
+					});
+				})
+				.catch((e) => {
+					console.log("Failed transaction", e);
+					return fail(400, { message: e.message });
+				});
+		}
+
+		// Update the salesmen
+		const currentSalesmen = await getSalesmenContactIds();
+
+		const newSalesmen = salesmen.filter((c) => !currentSalesmen.includes(c));
+		const deleteSalesmen = currentSalesmen.filter((c) => !salesmen.includes(c));
+
+		await prisma.salesman.deleteMany({
+			where: {
+				contactId: {
+					in: deleteSalesmen,
+				},
+			},
+		});
+		await prisma.salesman.createMany({
+			data: newSalesmen.map((s) => {
+				return {
+					id: randomUUID(),
+					contactId: s,
+					state: 1,
+				};
+			}),
+		});
+
+		return { success: true, timestamp: new Date().getTime() };
+	},
+} satisfies Actions;

--- a/src/routes/(manage)/admin/match-accounts/+page.svelte
+++ b/src/routes/(manage)/admin/match-accounts/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+import { enhance } from "$app/forms";
+import { fullNameFromPerson } from "$lib/format/fullNameFromPerson";
+
+const { data, form } = $props();
+
+let submitButton: HTMLButtonElement;
+
+type Changes = {
+	licenses: UpdateObject;
+	merge: {
+		primary: string;
+		ids: MergeAccount[];
+	};
+	salesmen: string[];
+};
+
+const defaultChanges = {
+	licenses: {},
+	salesmen: data.salesmen,
+	merge: {
+		primary: "",
+		ids: [],
+	},
+};
+
+let lastSubmitted = $state(0);
+
+type MergeAccount = { contact: string; id: string };
+
+type UpdateObject = { [id: string]: string };
+
+let changes: Changes = $state(defaultChanges);
+
+const updateMergeList = ({ contact, id }: MergeAccount, selected: boolean) => {
+	const newAccounts = selected
+		? changes.merge.ids.slice()
+		: changes.merge.ids.filter((a) => a.id !== id);
+	if (selected) {
+		newAccounts.push({ contact, id });
+	}
+
+	changes.merge.ids = newAccounts;
+};
+$effect(() => {
+	if (!form || !form.success || form.timestamp === lastSubmitted) {
+		return;
+	}
+
+	lastSubmitted = form.timestamp;
+	changes = {
+		...changes,
+		licenses: {},
+		salesmen: data.salesmen,
+		merge: {
+			primary: "",
+			ids: [],
+		},
+	};
+});
+</script>
+
+<h2 class="underline text-lg">Missing Accounts</h2>
+
+<form
+  method="post"
+  action="?/save"
+  use:enhance={() => {
+    return async ({ update }) => {
+      await update({ reset: false });
+    };
+  }}
+>
+  {#each Object.entries(changes.licenses) as [k, v]}
+    <span>
+      <input type="hidden" name={`${k}-license`} value={v} />
+    </span>
+  {/each}
+  <div class="flex gap-x-2 items-end">
+    <label class="flex-1">
+      Select primary
+      <select
+        bind:value={changes.merge.primary}
+        name={"link-primary"}
+        class="select bg-surface-600"
+      >
+        {#each changes.merge.ids as { contact, id }}
+          <option value={id}>
+            {contact}
+          </option>
+        {/each}
+      </select>
+    </label>
+    <button
+      class="btn-md preset-tonal-secondary h-full"
+      type="button"
+      disabled={changes.merge.ids.length > 0
+        ? changes.merge.ids.length < 2 || !changes.merge.primary
+        : false}
+      onclick={() => {
+        if (data.salesmen.length !== changes.salesmen.length) {
+          if (
+            !confirm(
+              "Updating salesmen; any removed will unlink the vehicle from the salesman.",
+            )
+          ) {
+            return;
+          }
+        }
+
+        if (changes.merge.ids.length) {
+          if (!confirm("Merging accounts")) {
+            return;
+          }
+        }
+        submitButton.click();
+      }}
+    >
+      Update
+    </button>
+    <button bind:this={submitButton} class="hidden"> Submit </button>
+  </div>
+  <table class="table relative">
+    <thead class="sticky top-0 bg-surface-900 !text-white font-bold underline">
+      <tr>
+        <td> Merge </td>
+        <td> Last Name </td>
+
+        <td> First Name </td>
+        <td> License # </td>
+        <td> Is Salesman </td>
+      </tr>
+    </thead>
+    <tbody>
+      {#each data.missing as missing}
+        {@const merging = changes.merge.ids.findIndex(
+          (m) => m.id === missing.id,
+        )}
+        <tr class="odd:bg-surface-500/25">
+          <td>
+            <label>
+              <input
+                name="link-id"
+                type="checkbox"
+                checked={merging !== -1}
+                value={missing.id}
+                onchange={(e) => {
+                  const selected = e.target.checked;
+                  updateMergeList(
+                    {
+                      id: missing.id,
+                      contact: `${fullNameFromPerson({ person: missing })} - ${missing.account?.licenseNumber}`,
+                    },
+                    selected,
+                  );
+                }}
+              />
+            </label>
+          </td>
+          <td>
+            {missing.lastName}
+          </td>
+          <td>
+            {missing.firstName}
+          </td>
+          <td>
+            <input
+              class="mr-2"
+              defaultvalue={missing.account?.licenseNumber || ""}
+              onchange={(e) => {
+                changes.licenses[missing.id] = e.target?.value || "";
+              }}
+            />
+            {#if missing.account?.id}
+              <a href={`/accounts/${missing.account.id}`}> Account Page </a>
+            {/if}
+          </td>
+          <td>
+            <input
+              name="salesman"
+              type="checkbox"
+              checked={changes.salesmen.includes(missing.id)}
+              value={missing.id}
+              onchange={(e) => {
+                const selected = e.target.checked;
+                if (!selected) {
+                  changes.salesmen = changes.salesmen.filter(
+                    (s) => s !== missing.id,
+                  );
+                  return;
+                }
+                const newSalesmen = changes.salesmen.slice();
+                newSalesmen.push(missing.id);
+
+                changes.salesmen = newSalesmen;
+              }}
+            />
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</form>


### PR DESCRIPTION
Display all persons in a table with matching account.

- Use checkboxes to select accounts to merge, then select a primary account.
- Create / remove salesmen with a second set of checkboxes.

Also, improve hash use for navigation and selection with tabs.