### PR TITLE
Deal Stats

### DIFF
--- a/src/lib/finance/calc.ts
+++ b/src/lib/finance/calc.ts
@@ -52,7 +52,10 @@ export const calcFinance = (
 		(sellingTradeDiff * totalTaxPercent) / 100.0,
 	);
 
-	const unpaidCashBalance = sellingTradeDiff - p.priceDown + totalTaxDollar;
+	const unpaidCashBalance =
+		p.term > 0
+			? sellingTradeDiff - p.priceDown + totalTaxDollar
+			: sellingTradeDiff + totalTaxDollar;
 
 	const financeAmount = unpaidCashBalance + p.filingFees;
 

--- a/src/lib/format/fullNameFromPerson.ts
+++ b/src/lib/format/fullNameFromPerson.ts
@@ -4,6 +4,7 @@ export function fullNameFromPerson({
 	person,
 	format = "lastFirst",
 	titleCase = true,
+	withCell = false,
 }: FullNameParams) {
 	const {
 		nameSuffix: suffix,
@@ -11,6 +12,7 @@ export function fullNameFromPerson({
 		firstName,
 		middleInitial,
 		namePrefix: prefix,
+		phonePrimary: cell,
 	} = person;
 
 	let name = "";
@@ -30,9 +32,20 @@ export function fullNameFromPerson({
 			.filter(Boolean)
 			.join(", ");
 	} else {
-		name = [prefix, firstName, middleInitial, lastName, suffix]
+		name = [
+			prefix,
+			firstName,
+			middleInitial,
+			lastName,
+			suffix,
+			withCell ? cell : undefined,
+		]
 			.filter(Boolean)
 			.join(" ");
+	}
+
+	if (withCell) {
+		name = `${name} - ${cell || "NO PHONE PRIMARY"}`.trim();
 	}
 
 	if (titleCase) {

--- a/src/lib/format/index.ts
+++ b/src/lib/format/index.ts
@@ -4,6 +4,7 @@ export type FullNameParams = {
 	person: Partial<Person | DealPerson>;
 	format?: "firstLast" | "lastFirst";
 	titleCase?: boolean;
+	withCell?: boolean;
 };
 
 import { fullNameFromPerson } from "./fullNameFromPerson";

--- a/src/lib/server/database/account/index.ts
+++ b/src/lib/server/database/account/index.ts
@@ -22,5 +22,6 @@ export const contactSelect = {
 		id: true,
 		lastName: true,
 		firstName: true,
+		phonePrimary: true,
 	},
 };

--- a/src/routes/(manage)/deals/+page.svelte
+++ b/src/routes/(manage)/deals/+page.svelte
@@ -108,6 +108,10 @@ $effect(() => {
 const finance = $derived(calcFinance(deal));
 
 $effect(() => {
+	if (deal.term !== 0 || deal.priceDown === finance.unpaidCashBalance) return;
+	deal.priceDown = finance.unpaidCashBalance;
+});
+$effect(() => {
 	if (deal.dealType === "cash" && deal.term !== 0) {
 		deal.term = 0;
 	} else if (deal.dealType === "credit" && deal.term === 0) {
@@ -304,7 +308,7 @@ $effect(() => {
         bind:value={deal.priceDown}
         name={"priceDown"}
         type="number"
-        step={10}
+        step={isCredit ? 10 : 0.01}
         min={0}
         class="input"
       />


### PR DESCRIPTION
Added features to:

- update the down payment value for cash deals,
- better display the deal's stats, refactoring to use a standard snippet and away from disabled inputs
  - add additional stats for cash deals
  - hide the deal form while printing; relevant info replicated in stats section.